### PR TITLE
Implement Shortest Path in Unweighted Graph using BFS in Java

### DIFF
--- a/Java/algorithms/graph_algorithms/ShortestPathBFS.java
+++ b/Java/algorithms/graph_algorithms/ShortestPathBFS.java
@@ -1,0 +1,63 @@
+package Java.algorithms.graph_algorithms;
+
+import java.util.*;
+
+/**
+ * ShortestPathBFS
+ * 
+ * Computes shortest distances from a source vertex to all other vertices in an unweighted graph
+ * using Breadth-First Search (BFS).
+ */
+public class ShortestPathBFS {
+
+    /**
+     * Computes shortest distances from source to all vertices
+     * 
+     * @param graph adjacency list of the graph
+     * @param source source vertex
+     * @return array of distances (-1 if vertex is unreachable)
+     */
+    public static int[] shortestPath(int[][] graph, int source) {
+        int n = graph.length;
+        int[] distance = new int[n];
+        Arrays.fill(distance, -1); // initialize distances as -1
+        boolean[] visited = new boolean[n];
+
+        Queue<Integer> queue = new LinkedList<>();
+        queue.offer(source);
+        visited[source] = true;
+        distance[source] = 0;
+
+        while (!queue.isEmpty()) {
+            int current = queue.poll();
+
+            for (int neighbor : graph[current]) {
+                if (!visited[neighbor]) {
+                    visited[neighbor] = true;
+                    distance[neighbor] = distance[current] + 1;
+                    queue.offer(neighbor);
+                }
+            }
+        }
+
+        return distance;
+    }
+
+    // Test cases
+    public static void main(String[] args) {
+        // Test case 1: small connected graph
+        int[][] graph1 = { {1, 2}, {0, 3}, {0, 3}, {1, 2} };
+        int[] result1 = shortestPath(graph1, 0);
+        System.out.println(Arrays.toString(result1)); // Expected: [0, 1, 1, 2]
+
+        // Test case 2: disconnected graph
+        int[][] graph2 = { {1}, {0}, {}, {} };
+        int[] result2 = shortestPath(graph2, 0);
+        System.out.println(Arrays.toString(result2)); // Expected: [0, 1, -1, -1]
+
+        // Test case 3: single-node graph
+        int[][] graph3 = { {} };
+        int[] result3 = shortestPath(graph3, 0);
+        System.out.println(Arrays.toString(result3)); // Expected: [0]
+    }
+}

--- a/Java/data_structures/linked_lists/Detect_cycle.java
+++ b/Java/data_structures/linked_lists/Detect_cycle.java
@@ -1,3 +1,24 @@
+// File: Detecycle.java
+
+/**
+ * Detect Cycle in a Linked List
+ *
+ * Description:
+ * This algorithm detects whether a singly linked list contains a cycle.
+ * It uses Floyd’s Tortoise and Hare Algorithm:
+ *   - A slow pointer moves one step at a time.
+ *   - A fast pointer moves two steps at a time.
+ * If there is a cycle, the fast pointer will eventually meet the slow pointer.
+ * If there is no cycle, the fast pointer will reach the end of the list (null).
+ *
+ * Time Complexity: O(n) - each node is visited at most twice
+ * Space Complexity: O(1) - only two pointers are used
+ *
+ * Use Cases:
+ *   - Detecting loops in linked lists
+ *   - Applications in graph cycles, network routing, and memory management
+ */
+
 class ListNode {
     int val;
     ListNode next;
@@ -9,19 +30,31 @@ class ListNode {
 
 public class Detect_cycle {
 
+    /**
+     * Detects if the linked list has a cycle.
+     *
+     * @param head The head node of the linked list
+     * @return true if there is a cycle, false otherwise
+     */
     public static boolean hasCycle(ListNode head) {
         if (head == null || head.next == null) return false;
 
-        ListNode slow = head, fast = head;
+        ListNode slow = head;  // moves 1 step at a time
+        ListNode fast = head;  // moves 2 steps at a time
+
         while (fast != null && fast.next != null) {
-            slow = slow.next;
-            fast = fast.next.next;
-            if (slow == fast) return true;
+            slow = slow.next;          // advance slow pointer
+            fast = fast.next.next;     // advance fast pointer
+
+            if (slow == fast) return true; // cycle detected
         }
-        return false;
+
+        return false; // no cycle
     }
 
+    // Driver code for testing
     public static void main(String[] args) {
+        // Test 1: List with cycle
         ListNode node1 = new ListNode(3);
         ListNode node2 = new ListNode(2);
         ListNode node3 = new ListNode(0);
@@ -30,14 +63,19 @@ public class Detect_cycle {
         node2.next = node3;
         node3.next = node4;
         node4.next = node2; // cycle
-        System.out.println("Test 1: " + hasCycle(node1)); // true
+        System.out.println("Test 1 (with cycle): " + hasCycle(node1)); // true
 
+        // Test 2: List without cycle
         ListNode nodeA = new ListNode(1);
         ListNode nodeB = new ListNode(2);
         nodeA.next = nodeB;
-        System.out.println("Test 2: " + hasCycle(nodeA)); // false
+        System.out.println("Test 2 (no cycle): " + hasCycle(nodeA)); // false
 
+        // Test 3: Single node without cycle
         ListNode single = new ListNode(1);
-        System.out.println("Test 3: " + hasCycle(single)); // false
+        System.out.println("Test 3 (single node): " + hasCycle(single)); // false
+
+        // Test 4: Empty list
+        System.out.println("Test 4 (empty list): " + hasCycle(null)); // false
     }
 }

--- a/Java/data_structures/linked_lists/Detect_cycle.java
+++ b/Java/data_structures/linked_lists/Detect_cycle.java
@@ -1,0 +1,43 @@
+class ListNode {
+    int val;
+    ListNode next;
+    ListNode(int val) {
+        this.val = val;
+        this.next = null;
+    }
+}
+
+public class Detect_cycle {
+
+    public static boolean hasCycle(ListNode head) {
+        if (head == null || head.next == null) return false;
+
+        ListNode slow = head, fast = head;
+        while (fast != null && fast.next != null) {
+            slow = slow.next;
+            fast = fast.next.next;
+            if (slow == fast) return true;
+        }
+        return false;
+    }
+
+    public static void main(String[] args) {
+        ListNode node1 = new ListNode(3);
+        ListNode node2 = new ListNode(2);
+        ListNode node3 = new ListNode(0);
+        ListNode node4 = new ListNode(-4);
+        node1.next = node2;
+        node2.next = node3;
+        node3.next = node4;
+        node4.next = node2; // cycle
+        System.out.println("Test 1: " + hasCycle(node1)); // true
+
+        ListNode nodeA = new ListNode(1);
+        ListNode nodeB = new ListNode(2);
+        nodeA.next = nodeB;
+        System.out.println("Test 2: " + hasCycle(nodeA)); // false
+
+        ListNode single = new ListNode(1);
+        System.out.println("Test 3: " + hasCycle(single)); // false
+    }
+}


### PR DESCRIPTION
## Problem Statement

This PR implements a solution for computing the shortest path from a source vertex to all other vertices in an unweighted graph using Breadth-First Search (BFS).

Input: Graph represented as an adjacency list, and a source vertex s.

Output: Array of distances from the source vertex to all other vertices.

Unreachable vertices are represented with -1.

## Example:

Input: graph = [[1,2],[0,3],[0,3],[1,2]], s = 0
Output: distances = [0,1,1,2]

## Approach

Use a queue to perform BFS traversal starting from the source vertex.

Maintain a visited array to avoid revisiting vertices.

Track distances in an array initialized with -1.

For each visited neighbor, set distance[neighbor] = distance[current] + 1.

Return the distance array at the end of BFS.

Time Complexity: O(V + E) — traverses each vertex and edge once.
Space Complexity: O(V) — for the visited array, distance array, and the queue.

## Changes Made

Added a new Java file: Java/algorithms/graph_algorithms/ShortestPathBFS.java

Implemented BFS-based shortest path algorithm.

Added main() method with test cases covering:

Connected graph

Disconnected graph

Single-node graph

Edge Cases Handled

Graphs with disconnected components

Single-node graphs

Vertices unreachable from the source

## References

Breadth-First Search - GeeksforGeeks

Shortest Path in Unweighted Graph


This PR Fixes #403  


I am submitting this PR for the BFS shortest path issue. All test cases have been included and documented.